### PR TITLE
chore: bump avtrdb to v2

### DIFF
--- a/src/provider/avtrdb.rs
+++ b/src/provider/avtrdb.rs
@@ -8,7 +8,7 @@ use crate::{
     USER_AGENT,
 };
 
-const BASE_URL: &str = "https://api.avtrdb.com/v1/";
+const BASE_URL: &str = "https://api.avtrdb.com/v2/";
 
 pub struct AvtrDB {
     client:      Client,


### PR DESCRIPTION
I intend to deprecate v1 within this or the next month, so this change is to accomodate that.
There in no API change, just that v1 will stop responding at some point (i dont want to deal with redirects as i want to remove dead code as much as i can)

Let me know if u have feedback :]

edit:
just now noticed the unrelated changes (rustfmt auto save lol)