### PR TITLE
Add Cute Avatar Search to search providers list

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ default = [
     "cache",
     "avtrdb",
     "avtrzip",
+    "cutedb",
     "kitsunedb",
     "nsvr",
     "paw",
@@ -72,6 +73,7 @@ default = [
 cache = ["dep:tokio-rusqlite-new"]
 avtrdb = ["dep:reqwest", "discord"]
 avtrzip = ["dep:reqwest"]
+cutedb = ["dep:reqwest"]
 kitsunedb = ["dep:reqwest"]
 nsvr = ["dep:reqwest", "discord"]
 paw = ["dep:reqwest"]

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ You must manually close it to scan the collected avatars, it will re-open automa
 - [VRCDB - Avatar Search] - [Discord](https://discord.gg/q427ecnUvj) / [VRCX](https://vrcx.vrcdb.com/avatars/Avatar/VRCX) / [Web](https://vrcdb.com) / [World](https://vrchat.com/home/world/wrld_1146f625-5d42-40f5-bfe7-06a7664e2796)
 - [KitsuneDB] - [VRCX](https://avtr.fumikoecho.net/api/integrations/avatars/vrcx) / [Web](https://avtr.fumikoecho.net)
 - [VRCWB - World Balancer] - [VRCX](https://avatarwbvrcxsearch.worldbalancer.com/vrcx_search) / [Web](https://avatar.worldbalancer.com/)
+- [CuteDB - Cutest Avatar Search] - [Discord](https://discord.gg/pR3uECQFs9) / [VRCX](https://avtr.icu/vrcx) / [Web](https://avtr.icu/) / [World](https://vrchat.com/home/world/wrld_15c6ff42-a779-40a2-8c30-862d9015795e)
 
 #### Unsupported Avatar Database Providers
 
@@ -83,6 +84,8 @@ Additional contributions welcome, please open an issue, pull request, or join Di
 [VRCWB - World Balancer]: https://avatar.worldbalancer.com
 
 [KitsuneDB]: https://avtr.fumikoecho.net
+
+[CuteDB - Cutest Avatar Search]: https://avtr.icu
 
 [Just H Party]: https://avtr.just-h.party
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,10 @@ use tracing::level_filters::LevelFilter;
 use tracing_subscriber::{fmt::time::OffsetTime, EnvFilter};
 use vrc_log::{
     provider,
-    provider::{avtrdb::AvtrDBActor, kitsunedb::KitsuneDBActor, prelude::*, ProviderKind},
+    provider::{
+        avtrdb::AvtrDBActor, cutedb::CuteDBActor, kitsunedb::KitsuneDBActor, prelude::*,
+        ProviderKind,
+    },
     settings::Settings,
     vrchat::{VRCHAT_AMP_PATH, VRCHAT_LOW_PATH},
     CARGO_PKG_HOMEPAGE,
@@ -104,6 +107,7 @@ async fn main() -> Result<()> {
     let settings: &'static Settings = Box::leak(Box::new(settings));
 
     let (mut avtrdb_actor, avtrdb_sender) = AvtrDBActor::new(settings);
+    let (mut cutedb_actor, cutedb_sender) = CuteDBActor::new();
     let (mut kitsunedb_actor, kitsunedb_sender) = KitsuneDBActor::new(settings);
 
     let providers = settings
@@ -125,10 +129,13 @@ async fn main() -> Result<()> {
             ProviderKind::AVTRZIP => provider!(AvtrZip::default()),
             #[cfg(feature = "kitsunedb")]
             ProviderKind::KITSUNEDB => provider!(KitsuneDB::new(kitsunedb_sender.clone())),
+            #[cfg(feature = "cutedb")]
+            ProviderKind::CUTEDB => provider!(CuteDB::new(cutedb_sender.clone())),
         })
         .collect::<Vec<_>>();
 
     let avtrdb_handle = tokio::spawn(async move { avtrdb_actor.run().await });
+    let cutedb_handle = tokio::spawn(async move { cutedb_actor.run().await });
     let kitsunedb_handle = tokio::spawn(async move { kitsunedb_actor.run().await });
 
     let handle = tokio::spawn(vrc_log::process_avatars(providers, settings, (tx, rx)));
@@ -183,6 +190,7 @@ async fn main() -> Result<()> {
     // the matching change in provider/kitsunedb.rs and provider/avtrdb.rs.
     handle.abort();
     drop(avtrdb_sender);
+    drop(cutedb_sender);
     drop(kitsunedb_sender);
 
     let shutdown_timeout = std::time::Duration::from_secs(90);
@@ -191,6 +199,12 @@ async fn main() -> Result<()> {
         .is_err()
     {
         error!("avtrDB actor did not finish flushing before shutdown timed out");
+    }
+    if tokio::time::timeout(shutdown_timeout, cutedb_handle)
+        .await
+        .is_err()
+    {
+        error!("CuteDB actor did not finish flushing before shutdown timed out");
     }
     if tokio::time::timeout(shutdown_timeout, kitsunedb_handle)
         .await

--- a/src/provider/cutedb.rs
+++ b/src/provider/cutedb.rs
@@ -1,0 +1,145 @@
+use std::time::Duration;
+
+use anyhow::{bail, Result};
+use flume::{Receiver, Sender};
+use reqwest::{Client, StatusCode};
+use serde_json::json;
+use tokio::time::Instant;
+
+use crate::{
+    provider::{Provider, ProviderKind},
+    USER_AGENT,
+};
+
+const URL: &str = "https://avtr.icu/upload-bulk";
+
+const FLUSH_INTERVAL: Duration = Duration::from_secs(2 * 60);
+const FLUSH_THRESHOLD: usize = 100;
+
+const RETRY_LIMIT: usize = 5;
+
+const LOG_NAME: &str = "CuteDB";
+
+pub struct CuteDB {
+    sender: Sender<String>,
+}
+
+pub struct CuteDBActor {
+    client:         Client,
+    buffer:         Vec<String>,
+    channel:        Receiver<String>,
+    flush_interval: Duration,
+    last_flush:     Instant,
+}
+
+impl CuteDBActor {
+    #[must_use]
+    pub fn new() -> (Self, Sender<String>) {
+        let (tx, rx) = flume::bounded(FLUSH_THRESHOLD);
+
+        (
+            Self {
+                client:         Client::default(),
+                buffer:         Vec::new(),
+                channel:        rx,
+                flush_interval: FLUSH_INTERVAL,
+                last_flush:     Instant::now(),
+            },
+            tx,
+        )
+    }
+
+    pub async fn run(&mut self) -> Result<()> {
+        while let Ok(id) = self.channel.recv_async().await {
+            self.buffer.push(id);
+
+            if self.buffer.len() >= FLUSH_THRESHOLD
+                || self.last_flush.elapsed() > self.flush_interval
+            {
+                match self.flush_buffer().await {
+                    Ok(()) => (),
+                    Err(err) => error!("[{LOG_NAME}]: Failed to flush buffer: {err}"),
+                }
+            }
+        }
+
+        if !self.buffer.is_empty()
+            && let Err(err) = self.flush_buffer().await
+        {
+            error!("[{LOG_NAME}]: Failed to flush buffer on shutdown: {err}");
+        }
+
+        Ok(())
+    }
+
+    pub async fn flush_buffer(&mut self) -> Result<()> {
+        let json: Vec<_> = self
+            .buffer
+            .iter()
+            .map(|id| json!({ "id": id }))
+            .collect();
+
+        let mut current_try = 0;
+        let mut success = false;
+        while current_try < RETRY_LIMIT && !success {
+            if current_try != 0 {
+                tokio::time::sleep(Duration::from_secs(10)).await;
+            }
+            debug!("[{LOG_NAME}] (try {current_try}) Sending {json:#?}");
+            current_try += 1;
+
+            let response = self
+                .client
+                .post(URL)
+                .header("User-Agent", USER_AGENT)
+                .json(&json)
+                .timeout(Duration::from_secs(5))
+                .send()
+                .await?;
+
+            let status = response.status();
+            let text = response.text().await?;
+            debug!("[{LOG_NAME}] {status} | {text}");
+
+            success = match status {
+                StatusCode::OK => true,
+                StatusCode::TOO_MANY_REQUESTS => {
+                    warn!("[{LOG_NAME}] 429 Rate Limit, trying again in 10 seconds");
+                    false
+                }
+                _ => {
+                    error!("[{LOG_NAME}] Unknown Error: {status} | {text}");
+                    false
+                }
+            };
+        }
+
+        if current_try >= RETRY_LIMIT {
+            bail!("[{LOG_NAME}] Failed after {current_try} retries to flush buffer, aborting");
+        }
+
+        self.buffer.clear();
+        self.last_flush = Instant::now();
+
+        Ok(())
+    }
+}
+
+impl CuteDB {
+    #[must_use]
+    pub const fn new(sender: Sender<String>) -> Self {
+        Self { sender }
+    }
+}
+
+#[async_trait::async_trait]
+impl Provider for CuteDB {
+    fn kind(&self) -> ProviderKind {
+        ProviderKind::CUTEDB
+    }
+
+    async fn send_avatar_id(&self, avatar_id: &str) -> Result<bool> {
+        self.sender.send_async(avatar_id.to_string()).await?;
+        Ok(true)
+    }
+}

--- a/src/provider/mod.rs
+++ b/src/provider/mod.rs
@@ -6,6 +6,8 @@ use strum::{Display, EnumIter};
 pub mod avtrdb;
 #[cfg(feature = "avtrzip")]
 pub mod avtrzip;
+#[cfg(feature = "cutedb")]
+pub mod cutedb;
 #[cfg(feature = "kitsunedb")]
 pub mod kitsunedb;
 #[cfg(feature = "nsvr")]
@@ -46,6 +48,9 @@ pub enum ProviderKind {
     #[cfg(feature = "kitsunedb")]
     #[strum(to_string = "KitsuneDB - Avatar Database")]
     KITSUNEDB = 1 << 6,
+    #[cfg(feature = "cutedb")]
+    #[strum(to_string = "CuteDB - Cutest Avatar Search")]
+    CUTEDB    = 1 << 7,
 }
 
 #[async_trait]

--- a/src/provider/prelude.rs
+++ b/src/provider/prelude.rs
@@ -2,6 +2,8 @@
 pub use super::avtrdb::AvtrDB;
 #[cfg(feature = "avtrzip")]
 pub use super::avtrzip::AvtrZip;
+#[cfg(feature = "cutedb")]
+pub use super::cutedb::CuteDB;
 #[cfg(feature = "kitsunedb")]
 pub use super::kitsunedb::KitsuneDB;
 #[cfg(feature = "nsvr")]

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -68,7 +68,8 @@ impl Settings {
         let providers = {
             let providers = ProviderKind::iter().collect::<Vec<_>>();
             let enabled = MultiSelect::new("Select which providers to use:", providers.clone())
-                .with_default(&[0, 1, 2, 3, 4, 5, 6])
+                .with_page_size(providers.len())
+                .with_default(&[0, 1, 2, 3, 4, 5, 6, 7])
                 .with_validator(|list: &[ListOption<&ProviderKind>]| {
                     if list.is_empty() {
                         let message = String::from("You must select at least one.");


### PR DESCRIPTION
feat: Add Cute Avatar Search as a search provider

- Added Cute Avatar Search to the provider list, following the AvtrDB request shape for compatibility.

- Fixed the search provider list to correctly display all 7 providers instead of 6. without scrolling

- Cute Avatar Search follows the same blacklisting standards as the other search providers, with additional methods

- Tested locally; everything works as expected.

do note please go easy this is my first time contributing to a rust project 🥺 