### PR TITLE
fix: use std::thread::sleep instead of block_on in get_user

### DIFF
--- a/src/discord.rs
+++ b/src/discord.rs
@@ -40,9 +40,7 @@ impl Discord {
 #[once(sync_writes = true)]
 pub fn get_user() -> Option<PartialUser> {
     let discord = Discord::start();
-    tokio::runtime::Handle::current().block_on(async {
-        tokio::time::sleep(Duration::from_secs(5)).await;
-    });
+    std::thread::sleep(Duration::from_secs(5));
     discord.client.shutdown().ok()?;
 
     if let Some(user) = discord.user.lock().as_ref() {


### PR DESCRIPTION
Calling Handle::current().block_on() from a sync function while already inside a #[tokio::main] async context panics. Switch to std::thread::sleep which is correct for a synchronous cached function.